### PR TITLE
WIP: Zarr @ SciPy 2019 Blog Post

### DIFF
--- a/_posts/2019-07-12-zarr-at-scipy-2019.md
+++ b/_posts/2019-07-12-zarr-at-scipy-2019.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title:  "Zarr @ SciPy 2019"
+date:   2019-07-12
+categories: scipy
+---
+
+SciPy 2019 has been a great experience. It's been a huge pleasure to
+present Zarr and explore ways that it can connect with all of the
+other amazing developments in and around the SciPy ecosystem. Here is
+the video of the Zarr presentation:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qyJXBlrdzBs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+... and [here are the slides](https://zarr-developers.github.io/slides/scipy-2019.html).
+
+Here is a selection of other talks and events at SciPy that did or
+could connect with Zarr in some way...
+
+@@TODO something about Pangeo BoF, diversity of people interested in
+Pangeo's approach, getting data into a cloud-native format like Zarr
+or cloud-optimised GeoTIFF is a key step.
+
+@@TODO something about Sannon's talk on StarFish.
+
+@@TODO please add anything else.
+
+----
+
+Blog post written by [Alistair Miles](https://github.com/alimanfoo) and ... @@TODO.


### PR DESCRIPTION
This PR adds a brief blog post about SciPy 2019 with a link to the zarr talk, and links to any other talks/events that relate to Zarr in some way.