### PR TITLE
Move blog posts under /blog/:year/:month/:day

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ plugins:
   - jekyll-feed
   - jekyll-include-cache
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 
 # Exclude from processing.
@@ -77,3 +78,9 @@ footer:
     - label: "Gitter"
       icon: "fab fa-gitter"
       url: "https://gitter.im/zarr-developers/community"
+
+defaults:
+  - scope:
+      type: "posts"
+    values:
+      permalink: blog/:year/:month/:title/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,6 +13,8 @@ sidebar:
         url: '#features'
       - title: "Sponsorship"
         url: "#sponsorship"
+      - title: "Blog Posts"
+        url: "/posts"
       - title: "Slides"
         url: "/slides"
       - title: "Videos"

--- a/_posts/2019-05-02-zarr-2.3-release.md
+++ b/_posts/2019-05-02-zarr-2.3-release.md
@@ -2,6 +2,8 @@
 title:  "Zarr Python 2.3 release"
 date:   2019-05-23
 categories: zarr python release
+redirect_from:
+  - /zarr/python/release/2019/05/23/zarr-2.3-release.html
 
 layout: home
 author_profile: false

--- a/_posts/2019-06-19-zarr-v3-update.md
+++ b/_posts/2019-06-19-zarr-v3-update.md
@@ -2,6 +2,8 @@
 title:  "Zarr protocol v3 design update"
 date:   2019-06-19
 categories: zarr specs
+redirect_from:
+  - /zarr/specs/2019/06/19/zarr-v3-update.html
 
 layout: home
 author_profile: false

--- a/posts.md
+++ b/posts.md
@@ -1,0 +1,18 @@
+---
+layout: home
+author_profile: false
+title: Zarr Blog Posts
+permalink: /posts/
+sidebar:
+  title: "Content"
+  nav: sidebar
+---
+
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+      {{ post.excerpt }}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
- activates the redirect-from plugin
- redirects from the previous category-based urls
- adds a top-level posts page
- adds the top-level page to the sidebar

cc: @MSanKeys963 @alimanfoo

Tested locally with `bundle exec jekyll serve`