### PR TITLE
Add a new page for Zarr Office Hours

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,6 +15,8 @@ sidebar:
         url: '#applications'
       - title: "Adopters"
         url: "/adopters"
+      - title: "Office Hours"
+        url: "/office-hours"
       - title: "Features"
         url: '#features'
       - title: "Sponsorship"

--- a/office_hours/office_hours.md
+++ b/office_hours/office_hours.md
@@ -8,13 +8,11 @@ sidebar:
   nav: sidebar
 ---
 
-<p><font size="4">The office hours aim to better engage with the Zarr community and also help understand the .zarr storage format to anyone new to the format and community.</font></p>
+<p><font size="4">We’ll be hosting office hours on Wednesdays every two weeks. Please join us if you have questions about Zarr and want to learn more about the .zarr storage format. We’ll discuss the specification, the implementations, what’s new in the Zarr ecosystem, how you can get involved in the community and much more.</font></p>
 
-<p><font size="4">We'll be discuss the specification, the implementations, what's new in the Zarr ecosystem these days, how you can get involved and answer any questions related to the format and the community.</font></p>
+<p><font size="4">Office hours are a great place if you want to start using Zarr and have questions about whether Zarr suits your data storage needs. We’ll have a few items on the agenda to kickstart the meeting, but the overall agenda and structure of the office hours will be shaped according to the attendees’ and community’s needs.</font></p>
 
-<p><font size="4">We'll be mostly bootstrapping the agenda and overall structure of the office hours according to the attendees' and community's needs.</font></p>
-
-<p><font size="4">The office hours will be repeated bi-weekly. Please see the Zarr community calendar for exact timings:</font></p>
+<p><font size="4">Please see the Zarr community calendar for exact timings:</font></p>
 
 <iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?ctz=local&src=c_ba2k79i3u0lkf49vo0jre27j14%40group.calendar.google.com&ctz=Europe%2FBerlin" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script> 
 

--- a/office_hours/office_hours.md
+++ b/office_hours/office_hours.md
@@ -1,0 +1,21 @@
+---
+layout: single
+author_profile: false
+title: Zarr Office Hours
+permalink: /office-hours/
+sidebar:
+  title: "Content"
+  nav: sidebar
+---
+
+<p><font size="4">The office hours aim to better engage with the Zarr community and also help understand the .zarr storage format to anyone new to the format and community.</font></p>
+
+<p><font size="4">We'll be discuss the specification, the implementations, what's new in the Zarr ecosystem these days, how you can get involved and answer any questions related to the format and the community.</font></p>
+
+<p><font size="4">We'll be mostly bootstrapping the agenda and overall structure of the office hours according to the attendees' and community's needs.</font></p>
+
+<p><font size="4">The office hours will be repeated bi-weekly. Please see the Zarr community calendar for exact timings:</font></p>
+
+<iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?ctz=local&src=c_ba2k79i3u0lkf49vo0jre27j14%40group.calendar.google.com&ctz=Europe%2FBerlin" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script> 
+
+<font size="4">Download the <a href="https://calendar.google.com/calendar/ical/c_ba2k79i3u0lkf49vo0jre27j14%40group.calendar.google.com/public/basic.ics">.ics</a> file and add it to your calendar so won't miss any of our meetings!</font>


### PR DESCRIPTION
Hi all. 👋🏻 

Linking this from https://github.com/zarr-developers/community/issues/62 and #80.

I've added a landing page for Zarr's office hours. After merging the URL will be: https://zarr.dev/office-hours.

Here's what the page looks like:

<img width="1511" alt="Screenshot 2023-03-27 at 22 23 33" src="https://user-images.githubusercontent.com/20305658/228011548-23b7fd69-0985-4b3c-8470-6beb1920d11b.png">

<img width="1511" alt="Screenshot 2023-03-27 at 22 23 52" src="https://user-images.githubusercontent.com/20305658/228011621-df7c0b5b-2848-4834-8f22-5f9bb9695c44.png">

Suggestions/feedback are most welcome. Thanks!