### PR TITLE
Add page for Zarr implementations

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,29 +9,31 @@ main:
 sidebar:
   - title: About
     children:
-      - title: "Specification"
-        url: https://zarr-specs.readthedocs.io/
       - title: "Description"
         url: '#description'
       - title: "Applications"
         url: '#applications'
-      - title: "Adopters"
-        url: "/adopters"
-      - title: "Office Hours"
-        url: "/office-hours"
       - title: "Features"
         url: '#features'
-      - title: "Implementations"
-        url: '/implementations'
       - title: "Sponsorship"
         url: "#sponsorship"
-      - title: "Slides"
-        url: "/slides"
       - title: "Videos"
         url: "#videos"
-      - title: "ZEPs"
-        url: '/zeps'
-      - title: "Community"
-        url: '/community'
+  - title: Subpages
+    children:
+      - title: "Adopters"
+        url: "/adopters"
       - title: "Blog"
         url: '/blog'
+      - title: "Community"
+        url: '/community'
+      - title: "Implementations"
+        url: '/implementations'
+      - title: "Office Hours"
+        url: "/office-hours"
+      - title: "Slides"
+        url: "/slides"
+      - title: "Specification"
+        url: https://zarr-specs.readthedocs.io/
+      - title: "ZEPs"
+        url: '/zeps'

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,6 +9,8 @@ main:
 sidebar:
   - title: About
     children:
+      - title: "Specification"
+        url: https://zarr-specs.readthedocs.io/
       - title: "Description"
         url: '#description'
       - title: "Applications"
@@ -19,6 +21,8 @@ sidebar:
         url: "/office-hours"
       - title: "Features"
         url: '#features'
+      - title: "Implementations"
+        url: '/implementations'
       - title: "Sponsorship"
         url: "#sponsorship"
       - title: "Slides"
@@ -31,9 +35,3 @@ sidebar:
         url: '/community'
       - title: "Blog"
         url: '/blog'
-  - title: Other sites
-    children:
-      - title: "Specification"
-        url: https://zarr-specs.readthedocs.io/en/core-protocol-v3.0-dev/
-      - title: "Implementations"
-        url: https://github.com/zarr-developers/zarr_implementations

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -8,80 +8,41 @@ sidebar:
   nav: sidebar
 ---
 
-<font size="4">Zarr is a data storage format based on an open-source <a
+<font size="4">
+Zarr is a data storage format based on an open-source <a
 href="https://zarr-specs.readthedocs.io/">specification</a>, making
 implementations across several languages possible. It is used in various
 domains, including geospatial, bio-imaging, genomics, data science, and HPC. 🌏🔬🧬<br><br>
 
-Implementations are listed (in alphabetical order) as follows:</font>
+Implementations are listed (in alphabetical order) as follows:<br><br>
+</font>
+
+| C          | C++            | Java          | Javascript    | Julia     | Python        | R      | Rust      |
+|---         |---             |---            |---            |---        |---            |---     |---        |
+| [NetCDF-C] | [GDAL]         | [JZarr]       |  [Zarr.js]    | [Zarr.jl] | [Zarr-Python] | [Rarr] | [Rust-N5] |
+|            | [Tensorstore]  | [N5-Zarr]     |  [Zarr-js]    |           |               |        | [Zarr]    |
+|            | [Xtensor-Zarr] | [NetCDF-Java] |               |           |               |        |           |
+|            | [Z5]           |               |               |           |               |        |           |
+
+[NetCDF-C]: https://github.com/Unidata/netcdf-c
+[GDAL]: https://gdal.org/drivers/raster/zarr.html
+[JZarr]: https://github.com/bcdev/jzarr
+[Zarr.js]: https://github.com/gzuidhof/zarr.js
+[Zarr.jl]: https://github.com/JuliaIO/Zarr.jl
+[Zarr-Python]: https://github.com/zarr-developers/zarr-python
+[Rarr]: https://github.com/grimbough/Rarr
+[Rust-N5]: https://github.com/aschampion/rust-n5
+[Tensorstore]: https://github.com/google/tensorstore/
+[N5-Zarr]: https://github.com/saalfeldlab/n5-zarr
+[Zarr-js]: https://github.com/freeman-lab/zarr-js
+[Zarr]: https://github.com/sci-rs/zarr
+[Xtensor-Zarr]: https://github.com/xtensor-stack/xtensor-zarr
+[NetCDF-Java]: https://github.com/Unidata/netcdf-java
+[Z5]: https://github.com/constantinpape/z5
 
 <font size="4">
-
-<ul>
-  <li>C</li>
-    <ul>
-      <li><a href="https://github.com/Unidata/netcdf-c">NetCDF-C</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>C++</li>
-    <ul>
-      <li><a href="https://gdal.org/drivers/raster/zarr.html">GDAL</a></li>
-      <li><a href="https://github.com/google/tensorstore/">Tensorstore</a></li>
-      <li><a href="https://github.com/xtensor-stack/xtensor-zarr">Xtensor-Zarr</a></li>
-      <li><a href="https://github.com/constantinpape/z5">Z5</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>Java</li>
-    <ul>
-      <li><a href="https://github.com/bcdev/jzarr">JZarr</a></li>
-      <li><a href="https://github.com/saalfeldlab/n5-zarr">N5-Zarr</a></li>
-      <li><a href="https://github.com/Unidata/netcdf-java">NetCDF-Java</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>Javascript</li>
-    <ul>
-      <li><a href="https://github.com/gzuidhof/zarr.js">Zarr.js</a></li>
-      <li><a href="https://github.com/freeman-lab/zarr-js">Zarr-js</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>Julia</li>
-    <ul>
-      <li><a href="https://github.com/JuliaIO/Zarr.jl">Zarr.jl</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>Python</li>
-    <ul>
-      <li><a href="https://github.com/zarr-developers/zarr-python">Zarr-Python</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>R</li>
-    <ul>
-      <li><a href="https://github.com/grimbough/Rarr">Rarr</a></li>
-    </ul>
-  </ul>
-
-<ul>
-  <li>Rust</li>
-    <ul>
-      <li><a href="https://github.com/aschampion/rust-n5">Rust-N5</a></li>
-      <li><a href="https://github.com/sci-rs/zarr">Zarr</a></li>
-    </ul>
-  </ul>
-
 → Feel free to add any missing implementations by sending a PR to the website <a href="https://github.com/zarr-developers/zarr-developers.github.io/">repository</a>. 🤝🏻<br><br>
 
-→ It's relatively easy to implement Zarr from scratch. If you're up, feel free to join our <a href="https://zarr.dev/community-calls/">community meetings</a> and let us know. 💪🏻
-
+→ Get involved in various Zarr implementations by fixing bugs, resolving issues, improving documentation, or contributing to the codebase.
+If you've been doing any of these activities recently, we invite you to join our <a href="https://zarr.dev/community-calls/">community meetings</a> and share your work with us. We'd be delighted to showcase your efforts. 💪🏻
 </font>

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -18,7 +18,7 @@ Implementations are listed (in alphabetical order) as follows:<br><br>
 </font>
 
 | C          | C++            | Java          | Javascript    | Julia     | Python        | R      | Rust      |
-|---         |---             |---            |---            |---        |---            |---     |---        |
+|------------|----------------|---------------|---------------|-----------|---------------|--------|-----------|
 | [NetCDF-C] | [GDAL]         | [JZarr]       |  [Zarr.js]    | [Zarr.jl] | [Zarr-Python] | [Rarr] | [Rust-N5] |
 |            | [Tensorstore]  | [N5-Zarr]     |  [Zarr-js]    |           |               |        | [Zarr]    |
 |            | [Xtensor-Zarr] | [NetCDF-Java] |               |           |               |        |           |

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -1,0 +1,87 @@
+---
+layout: single
+author_profile: false
+title: Zarr Implementations
+permalink: /implementations/
+sidebar:
+  title: "Content"
+  nav: sidebar
+---
+
+<font size="4">Zarr is a data storage format based on an open-source <a
+href="https://zarr-specs.readthedocs.io/">specification</a>, making
+implementations across several languages possible. It is used in various
+domains, including geospatial, bio-imaging, genomics, data science, and HPC. 🌏🔬🧬<br><br>
+
+They are listed (in alphabetical order) as follows:</font>
+
+<font size="4">
+
+<ul>
+  <li>C</li>
+    <ul>
+      <li><a href="https://github.com/Unidata/netcdf-c">NetCDF-C</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>C++</li>
+    <ul>
+      <li><a href="https://gdal.org/drivers/raster/zarr.html">GDAL</a></li>
+      <li><a href="https://github.com/google/tensorstore/">Tensorstore</a></li>
+      <li><a href="https://github.com/xtensor-stack/xtensor-zarr">Xtensor-Zarr</a></li>
+      <li><a href="https://github.com/constantinpape/z5">Z5</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>Java</li>
+    <ul>
+      <li><a href="https://github.com/bcdev/jzarr">JZarr</a></li>
+      <li><a href="https://github.com/saalfeldlab/n5-zarr">N5-Zarr</a></li>
+      <li><a href="https://github.com/Unidata/netcdf-java">NetCDF-Java</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>Javascript</li>
+    <ul>
+      <li><a href="https://github.com/gzuidhof/zarr.js">Zarr.js</a></li>
+      <li><a href="https://github.com/freeman-lab/zarr-js">Zarr-js</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>Julia</li>
+    <ul>
+      <li><a href="https://github.com/JuliaIO/Zarr.jl">Zarr.jl</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>Python</li>
+    <ul>
+      <li><a href="https://github.com/zarr-developers/zarr-python">Zarr-Python</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>R</li>
+    <ul>
+      <li><a href="https://github.com/grimbough/Rarr">Rarr</a></li>
+    </ul>
+  </ul>
+
+<ul>
+  <li>Rust</li>
+    <ul>
+      <li><a href="https://github.com/aschampion/rust-n5">Rust-N5</a></li>
+      <li><a href="https://github.com/sci-rs/zarr">Zarr</a></li>
+    </ul>
+  </ul>
+
+→ Feel free to add any missing implementations by sending a PR to the website <a href="https://github.com/zarr-developers/zarr-developers.github.io/">repository</a>. 🤝🏻<br><br>
+
+→ It's relatively easy to implement Zarr from scratch. If you're up, feel free to join our <a href="https://zarr.dev/community-calls/">community meetings</a> and let us know. 💪🏻
+
+</font>

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -13,7 +13,7 @@ href="https://zarr-specs.readthedocs.io/">specification</a>, making
 implementations across several languages possible. It is used in various
 domains, including geospatial, bio-imaging, genomics, data science, and HPC. 🌏🔬🧬<br><br>
 
-They are listed (in alphabetical order) as follows:</font>
+Implementations are listed (in alphabetical order) as follows:</font>
 
 <font size="4">
 


### PR DESCRIPTION
Linking this from #80.

Added a new page for the Zarr implementations. After merging this PR, it can be accessed at https://zarr.dev/implementations. 

Thanks, @joshmoore, for helping me with this. 

Let me know what you all think; suggestions are welcome. Thanks!

<img width="1507" alt="Screenshot 2023-05-16 at 02 47 51" src="https://github.com/zarr-developers/zarr-developers.github.io/assets/20305658/c804bc9a-95dc-4802-ba8f-11fa26a07721">

<img width="1512" alt="Screenshot 2023-05-16 at 02 48 08" src="https://github.com/zarr-developers/zarr-developers.github.io/assets/20305658/9b5fb076-9aa8-4e71-b229-81d4e23fad89">