### PR TITLE
Add page for Zarr conventions

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -27,6 +27,8 @@ sidebar:
         url: '/blog'
       - title: "Community"
         url: '/community'
+      - title: "Conventions"
+        url: '/conventions'
       - title: "Implementations"
         url: '/implementations'
       - title: "Office Hours"

--- a/conventions/index.md
+++ b/conventions/index.md
@@ -20,6 +20,7 @@ Here are some of the conventions that are currently in use:<br>
 <li><a href="https://github.com/zarr-developers/geozarr-spec">GeoZarr</a></li>
 <li><a href="https://docs.unidata.ucar.edu/nug/current/nczarr_head.html">NCZarr</a></li>
 <li><a href="https://github.com/ome/ome-zarr-py">OME-Zarr</a></li>
+<li><a href="https://docs.xarray.dev/en/stable/internals/zarr-encoding-spec.html">Xarray</a></li>
 </ul>
 
 If you're working on/know a new convention and want to add it to the list, feel free

--- a/conventions/index.md
+++ b/conventions/index.md
@@ -1,0 +1,27 @@
+---
+layout: single
+author_profile: false
+title: Zarr Conventions
+sidebar:
+  title: "Content"
+  nav: sidebar
+---
+
+<font size="4">
+The Zarr storage format is used in various domains and has active communities
+for each field. These communities have established several conventions on top
+of Zarr.<br><br>
+
+Here are some of the conventions that are currently in use:<br>
+
+<ul>
+<li><a href="https://anndata.readthedocs.io/en/latest/">Anndata</a></li>
+<li><a href="https://github.com/openssbd/bdz">BDZ</a></li>
+<li><a href="https://github.com/zarr-developers/geozarr-spec">GeoZarr</a></li>
+<li><a href="https://docs.unidata.ucar.edu/nug/current/nczarr_head.html">NCZarr</a></li>
+<li><a href="https://github.com/ome/ome-zarr-py">OME-Zarr</a></li>
+</ul>
+
+If you're working on/know a new convention and want to add it to the list, feel free
+to send a PR to the website <a href="https://github.com/zarr-developers/zarr-developers.github.io/">repository</a>.
+</font>


### PR DESCRIPTION
Linking this from #80.

Added a new page for the public Zarr conventions. After merging this PR, it can be accessed at https://zarr.dev/conventions.

Let me know what you all think; suggestions are welcome. Thanks!

<img width="1512" alt="Screenshot 2023-05-21 at 14 09 35" src="https://github.com/zarr-developers/zarr-developers.github.io/assets/20305658/8107f995-e958-4a32-96ce-bf5e4e3dbed7">
