### PR TITLE
Changed the outdated twitter logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,7 @@ social:
 footer:
   links:
     - label: "Twitter"
-      icon: "fa-brands fa-square-x-twitter"
+      icon: "fa-brands fa-x-twitter"
       url: "https://twitter.com/zarr_dev"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"

--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,7 @@ social:
 footer:
   links:
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fa-brands fa-square-x-twitter"
       url: "https://twitter.com/zarr_dev"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"


### PR DESCRIPTION
closes #104 

This pull request addresses the outdated Twitter logo issue by replacing it with a more current and visually consistent icon. The new Twitter icon has been sourced from a licensed and suitable provider to ensure compliance with project licensing requirements.