### PR TITLE
Add redirects for numcodecs and its codecs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,5 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 
 gem "webrick", "~> 1.7"
+
+gem "jekyll-redirect-from"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ DEPENDENCIES
   github-pages
   jekyll-feed (~> 0.13)
   jekyll-include-cache
+  jekyll-redirect-from
   jekyll-sitemap
   kramdown-parser-gfm
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,7 @@ plugins:
   - jekyll-feed
   - jekyll-include-cache
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 
 # Exclude from processing.

--- a/numcodecs_redirects/adler32.md
+++ b/numcodecs_redirects/adler32.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/adler32
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/checksum32.html#adler32
+---

--- a/numcodecs_redirects/astype.md
+++ b/numcodecs_redirects/astype.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/astype
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/astype.html
+---

--- a/numcodecs_redirects/bitround.md
+++ b/numcodecs_redirects/bitround.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/bitround
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/bitround.html
+---

--- a/numcodecs_redirects/blosc.md
+++ b/numcodecs_redirects/blosc.md
@@ -1,0 +1,6 @@
+---
+permalink: /numcodecs/blosc
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/blosc.html
+---
+

--- a/numcodecs_redirects/bz2.md
+++ b/numcodecs_redirects/bz2.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/bz2
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/bz2.html
+---

--- a/numcodecs_redirects/crc32.md
+++ b/numcodecs_redirects/crc32.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/crc32
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/checksum32.html#crc32
+---

--- a/numcodecs_redirects/delta.md
+++ b/numcodecs_redirects/delta.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/delta
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/delta.html
+---

--- a/numcodecs_redirects/fixedscaleoffset.md
+++ b/numcodecs_redirects/fixedscaleoffset.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/fixedscaleoffset
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/fixedscaleoffset.html
+---

--- a/numcodecs_redirects/fletcher32.md
+++ b/numcodecs_redirects/fletcher32.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/fletcher32
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/checksum32.html#fletcher32
+---

--- a/numcodecs_redirects/gzip.md
+++ b/numcodecs_redirects/gzip.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/gzip
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/gzip.html
+---

--- a/numcodecs_redirects/jenkins_lookup3.md
+++ b/numcodecs_redirects/jenkins_lookup3.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/jenkins_lookup3
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/checksum32.html#jenkinslookup3
+---

--- a/numcodecs_redirects/lz4.md
+++ b/numcodecs_redirects/lz4.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/lz4
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/lz4.html
+---

--- a/numcodecs_redirects/lzma.md
+++ b/numcodecs_redirects/lzma.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/lzma
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/lzma.html
+---

--- a/numcodecs_redirects/numcodecs.md
+++ b/numcodecs_redirects/numcodecs.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/
+---

--- a/numcodecs_redirects/packbits.md
+++ b/numcodecs_redirects/packbits.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/packbits
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/packbits.html
+---

--- a/numcodecs_redirects/pcodec.md
+++ b/numcodecs_redirects/pcodec.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/pcodec
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/pcodec.html
+---

--- a/numcodecs_redirects/quantize.md
+++ b/numcodecs_redirects/quantize.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/quantize
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/quantize.html
+---

--- a/numcodecs_redirects/shuffle.md
+++ b/numcodecs_redirects/shuffle.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/shuffle
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/shuffle.html
+---

--- a/numcodecs_redirects/zfpy.md
+++ b/numcodecs_redirects/zfpy.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/zfpy
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/zfpy.html
+---

--- a/numcodecs_redirects/zlib.md
+++ b/numcodecs_redirects/zlib.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/zlib
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/zlib.html
+---

--- a/numcodecs_redirects/zstd.md
+++ b/numcodecs_redirects/zstd.md
@@ -1,0 +1,5 @@
+---
+permalink: /numcodecs/zstd
+redirect_to:
+  - https://numcodecs.readthedocs.io/en/stable/zstd.html
+---


### PR DESCRIPTION
Hi everyone.

I've added redirects for the numcodecs and its codecs as requested here: https://ossci.zulipchat.com/#narrow/stream/423692-Zarr/topic/numcodecs.20redirect

The full list can be seen here: https://github.com/zarr-developers/numcodecs/pull/524/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R75-R92

PS. The pcodec redirect is not functional currently because there hasn't been a release since https://github.com/zarr-developers/numcodecs/pull/501 landed. Once there's a release, the pcodec redirect (https://zarr.dev/numcodecs/pcodec) will work.

Please review. Thanks!

CC: @normanrz @joshmoore