### PR TITLE
implementations: add V2/V3 support and last updated

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -13,36 +13,85 @@ href="https://zarr-specs.readthedocs.io/">specification</a>, making
 implementations across several languages possible. It is used in various
 domains, including geospatial, bio-imaging, genomics, data science, and HPC. 🌏🔬🧬<br><br>
 
-Implementations are listed (in alphabetical order) as follows:<br><br>
+Zarr version 2 and 3 implementations are listed (in alphabetical order per language) as follows:<br><br>
 </font>
 
-| C          | C++            | Java          | Javascript    | Julia     | OCaml     | Python        | R         | Rust      |
-|------------|----------------|---------------|---------------|-----------|-----------|---------------|-----------|-----------|
-| [NetCDF-C] | [GDAL]         | [JZarr]       |  [Zarr.js]    | [Zarr.jl] | [Zarr-ml] | [Zarr-Python] | [Rarr]    | [Rust-N5] |
-|            | [Tensorstore]  | [N5-Zarr]     |  [Zarr-js]    |           |           | [Zarrita]     | [Pizzarr] | [Zarr]    |
-|            | [Xtensor-Zarr] | [NetCDF-Java] |  [Zarrita.js] |           |           |               |           | [Zarrs]   |
-|            | [Z5]           |               |               |           |           |               |           |           |
+| Language               | Implementation         | V2| V3| Latest Release/Commit        |
+|------------------------|------------------------|---|---|------------------------------|
+| C                      | [NetCDF-C]             | ✓ |   | ![][NetCDF-C-re]             |
+| C++                    | [GDAL]                 | ✓ |   | ![][GDAL-re]                 |
+| C++/Python             | [TensorStore]          | ✓ | ✓ | ![][tensorstore-lu]          |
+| C++                    | [xtensor-zarr]         | ✓ | ✗ | ![][xtensor-zarr-lu]         |
+| C++                    | [z5]                   | ✓ |   | ![][z5-re]                   |
+| Java                   | [JZarr]                | ✓ |   | ![][JZarr-lu]                |
+| Java                   | [n5-zarr]              | ✓ |   | ![][n5-zarr-lu]              |
+| Java                   | [netCDF-Java]          | ✓ |   | ![][netCDF-Java-re]          |
+| Java                   | [zarr-java]            | ? | ? | ![][zarr-java-re]            |
+| Javascript             | [Zarr.js]              | ✓ |   | ![][Zarr.js-re]              |
+| Javascript             | [zarr-js]              | ✓ |   | ![][zarr-js-lu]              |
+| Javascript             | [zarrita.js]           | ✓ | ✓ | ![][zarrita.js-re]           |
+| Julia                  | [Zarr.jl]              | ✓ |   | ![][Zarr.jl-re]              |
+| OCaml                  | [zarr-ml]              |   | ✓ | ![][zarr-ml-re]              |
+| Python                 | [Zarr-Python]          | ✓ | ✓ | ![][Zarr-Python-re]          |
+| Python                 | [Zarrita]              | ✓ | ✓ | ![][Zarrita-lu]              |
+| R                      | [pizzarr]              | ✓ |   | ![][pizzarr-lu]              |
+| R                      | [Rarr]                 | ✓ |   | ![][Rarr-lu]                 |
+| Rust                   | [charizarr]            |   | ? | ![][charizarr-lu]            |
+| Rust                   | [rust-N5]              |   |   | ![][rust-N5-lu]              |
+| Rust                   | [zarr]                 |   | ? | ![][zarr-lu]                 |
+| Rust                   | [zarr3-rs]             |   | ? | ![][zarr3-rs-lu]             |
+| Rust/Python/C          | [zarrs]                | ✓ | ✓ | ![][zarrs-re]                |
+
+<sup>✓ Likely conformant</sup>
+<sup>? Unknown conformance</sup>
+<sup>✗ Nonconformant</sup>
 
 [NetCDF-C]: https://github.com/Unidata/netcdf-c
+[NetCDF-C-re]: https://img.shields.io/github/release-date-pre/Unidata/netcdf-c
 [GDAL]: https://gdal.org/drivers/raster/zarr.html
+[GDAL-re]: https://img.shields.io/github/release-date-pre/OSGeo/gdal
 [JZarr]: https://github.com/bcdev/jzarr
+[JZarr-lu]: https://img.shields.io/github/last-commit/bcdev/jzarr
 [Zarr.js]: https://github.com/gzuidhof/zarr.js
+[Zarr.js-re]: https://img.shields.io/github/release-date-pre/gzuidhof/zarr.js
 [Zarr.jl]: https://github.com/JuliaIO/Zarr.jl
+[Zarr.jl-re]: https://img.shields.io/github/release-date-pre/JuliaIO/Zarr.jl
 [Zarr-Python]: https://github.com/zarr-developers/zarr-python
+[Zarr-Python-re]: https://img.shields.io/github/release-date-pre/zarr-developers/zarr-python
 [Zarrita]: https://github.com/scalableminds/zarrita
+[Zarrita-lu]: https://img.shields.io/github/last-commit/scalableminds/zarrita
 [Rarr]: https://github.com/grimbough/Rarr
-[Rust-N5]: https://github.com/aschampion/rust-n5
-[Tensorstore]: https://github.com/google/tensorstore/
-[N5-Zarr]: https://github.com/saalfeldlab/n5-zarr
-[Zarr-js]: https://github.com/freeman-lab/zarr-js
-[Zarr]: https://github.com/sci-rs/zarr
-[Xtensor-Zarr]: https://github.com/xtensor-stack/xtensor-zarr
-[NetCDF-Java]: https://github.com/Unidata/netcdf-java
-[Z5]: https://github.com/constantinpape/z5
-[Pizzarr]: https://keller-mark.github.io/pizzarr/
-[Zarrs]: https://github.com/LDeakin/zarrs
-[Zarrita.js]: https://github.com/manzt/zarrita.js
-[Zarr-ml]: https://github.com/zoj613/zarr-ml
+[Rarr-lu]: https://img.shields.io/github/last-commit/grimbough/Rarr
+[rust-N5]: https://github.com/aschampion/rust-n5
+[rust-N5-lu]: https://img.shields.io/github/last-commit/aschampion/rust-n5
+[TensorStore]: https://github.com/google/tensorstore/
+[TensorStore-lu]: https://img.shields.io/github/last-commit/google/tensorstore
+[n5-zarr]: https://github.com/saalfeldlab/n5-zarr
+[n5-zarr-lu]: https://img.shields.io/github/last-commit/saalfeldlab/n5-zarr
+[zarr-js]: https://github.com/freeman-lab/zarr-js
+[zarr-js-lu]: https://img.shields.io/github/last-commit/freeman-lab/zarr-js
+[zarr]: https://github.com/sci-rs/zarr
+[zarr-lu]: https://img.shields.io/github/last-commit/sci-rs/zarr
+[xtensor-zarr]: https://github.com/xtensor-stack/xtensor-zarr
+[xtensor-zarr-lu]: https://img.shields.io/github/last-commit/xtensor-stack/xtensor-zarr
+[netCDF-Java]: https://github.com/Unidata/netcdf-java
+[netCDF-Java-re]: https://img.shields.io/github/release-date-pre/Unidata/netcdf-java
+[z5]: https://github.com/constantinpape/z5
+[z5-re]: https://img.shields.io/github/release-date-pre/constantinpape/z5
+[pizzarr]: https://keller-mark.github.io/pizzarr/
+[pizzarr-lu]: https://img.shields.io/github/last-commit/keller-mark/pizzarr
+[zarrs]: https://github.com/LDeakin/zarrs
+[zarrs-re]: https://img.shields.io/github/release-date-pre/LDeakin/zarrs
+[zarrita.js]: https://github.com/manzt/zarrita.js
+[zarrita.js-re]: https://img.shields.io/github/release-date-pre/manzt/zarrita.js
+[zarr-ml]: https://github.com/zoj613/zarr-ml
+[zarr-ml-re]: https://img.shields.io/github/release-date-pre/zoj613/zarr-ml
+[zarr3-rs]: https://github.com/clbarnes/zarr3-rs
+[zarr3-rs-lu]: https://img.shields.io/github/last-commit/clbarnes/zarr3-rs
+[charizarr]: https://github.com/mpiannucci/charizarr
+[charizarr-lu]: https://img.shields.io/github/last-commit/mpiannucci/charizarr
+[zarr-java]: https://github.com/zarr-developers/zarr-java
+[zarr-java-re]: https://img.shields.io/github/release-date-pre/zarr-developers/zarr-java
 
 <font size="4">
 → Feel free to add any missing implementations by sending a PR to the website <a href="https://github.com/zarr-developers/zarr-developers.github.io/">repository</a>. 🤝🏻<br><br>


### PR DESCRIPTION
The current implementations table does not indicate the state of the implementations. Hopefully, this gives some indication without much maintenance burden. I've made some guesses about the Zarr V2/V3 support for each implementation.

```md
### Changes
- implementations:
  - transpose the table
  - add latest release/commit column
  - add Zarr V2/V3 support column
  - match capitalisation of implementation names to the author's intention
  - add implementations:
    - zarr-java (Java)
    - zarr3 (Rust)
    - charizarr (Rust)
```

I've also added some additional implementations. But they may not be worth including, given their maturity.

Partially addresses https://github.com/zarr-developers/zarr_implementations/issues/66