### PR TITLE
Update navigation for Zarr-Python 3.0

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,9 +2,9 @@ main:
   - title: "Documentation"
     url: "https://zarr.readthedocs.io/en/stable/"
   - title: "Contribute"
-    url: "https://zarr.readthedocs.io/en/stable/contributing.html"
-  - title: "Python Tutorial"
-    url: https://zarr.readthedocs.io/en/stable/tutorial.html
+    url: "https://zarr.readthedocs.io/en/stable/developers/contributing.html"
+  - title: "Python Quickstart"
+    url: "https://zarr.readthedocs.io/en/stable/quickstart.html"
 
 sidebar:
   - title: About


### PR DESCRIPTION
The user guide included a redirect but the contributing guide did not, so this PR updates the URL.