### PR TITLE
Add cpp-zarr to the implementations page

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -19,6 +19,7 @@ Zarr version 2 and 3 implementations are listed (in alphabetical order per langu
 | Language               | Implementation         | V2| V3| Latest Release/Commit        |
 |------------------------|------------------------|---|---|------------------------------|
 | C                      | [NetCDF-C]             | ✓ |   | ![][NetCDF-C-re]             |
+| C++                    | [cpp-zarr]             | ✓ |   | ![][cpp-zarr-re]             |
 | C++                    | [GDAL]                 | ✓ |   | ![][GDAL-re]                 |
 | C++/Python             | [TensorStore]          | ✓ | ✓ | ![][tensorstore-lu]          |
 | C++                    | [xtensor-zarr]         | ✓ | ✗ | ![][xtensor-zarr-lu]         |
@@ -48,6 +49,8 @@ Zarr version 2 and 3 implementations are listed (in alphabetical order per langu
 
 [NetCDF-C]: https://github.com/Unidata/netcdf-c
 [NetCDF-C-re]: https://img.shields.io/github/release-date-pre/Unidata/netcdf-c
+[cpp-zarr]: https://github.com/abcucberkeley/cpp-zarr
+[cpp-zarr-re]: https://img.shields.io/github/release-date/abcucberkeley/cpp-zarr
 [GDAL]: https://gdal.org/drivers/raster/zarr.html
 [GDAL-re]: https://img.shields.io/github/release-date-pre/OSGeo/gdal
 [JZarr]: https://github.com/bcdev/jzarr


### PR DESCRIPTION
Hello,

I'm Matthew Mueller from the Advanced Bioimaging Center at UC Berkeley. We created a C++ Zarr V2 implementation called [cpp-zarr](https://github.com/abcucberkeley/cpp-zarr). We use cpp-zarr extensively in our image processing pipeline, [PetaKit5D](https://github.com/abcucberkeley/PetaKit5D), which we published a [paper](https://doi.org/10.1038/s41592-024-02475-4) in Nature Methods for late last year. The implementation is in C++, but we also have [Matlab](https://github.com/abcucberkeley/cpp-zarr/releases) and [Python](https://pypi.org/project/cpp-zarr/) versions available. I wanted to see if we could get it added to the implementation page.

Best,

Matthew Mueller